### PR TITLE
chore: Update test configuration for coverage reporting

### DIFF
--- a/tests/backend/Directory.Build.props
+++ b/tests/backend/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
 	<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../../src/backend'))" />
-	<PropertyGroup Condition="'$(IsTestProject)' == 'true'">
-		<TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --coverlet-include [WebApi]* --coverlet-include [ApiClient]* --coverlet-exclude-by-file **/Migrations/*.cs</TestingPlatformCommandLineArguments>
-	</PropertyGroup>
+	<!-- coverlet.MTP picks up testconfig.json next to the test assembly. The shared file lives in tests/backend/ and is linked into each test project's output. -->
+	<ItemGroup Condition="'$(IsTestProject)' == 'true'">
+		<None Include="$(MSBuildThisFileDirectory)testconfig.json" Link="testconfig.json" CopyToOutputDirectory="PreserveNewest" />
+	</ItemGroup>
 </Project>

--- a/tests/backend/testconfig.json
+++ b/tests/backend/testconfig.json
@@ -1,0 +1,9 @@
+{
+  "platformOptions": {
+    "Coverlet": {
+      "include": "[WebApi]*,[ApiClient]*",
+      "excludeByFile": "**/Migrations/*.cs",
+      "excludeByAttribute": "ExcludeFromCodeCoverage,ExcludeFromCodeCoverageAttribute,GeneratedCodeAttribute,CompilerGeneratedAttribute"
+    }
+  }
+}


### PR DESCRIPTION
Refactored the test project configuration in Directory.Build.props to include a linked testconfig.json file, which centralizes coverlet settings for coverage reporting. This change enhances maintainability and clarity in the test setup.

<!--- Provide a general summary of your changes in the Title above -->

## Description 💬
<!--- Describe your changes in detail -->

## Motivation and Context 🥅
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested? 🧪
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Local build ⚒️
- [ ] Local tests 🧪
- [ ] (optional) Local run and endpoint tested in swagger 🚀

## Screenshots (if appropriate) 💻

## Types of changes 🌊
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance (e.g. dependency updates, minor rewrites, code style changes)

## Checklist ☑️

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The pull request title starts with the jira case number (when applicable), e.g. "TEST-1234 Add some feature"
- [ ] The person responsible for following up on requested review changes has been assigned to the pull request
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Highly optional checks, only use these if you have a reason to do so ✔️

- [ ] This PR changes the database so I have added the *create-diagram* label to assist reviewers with a db diagram
- [ ] This PR changes platform or backend and I need others to be able to test against these changes before merging to dev, so I have added the *deploy-azure* label to deploy before merging the PR

## Checklist for the approver ✅

- [ ] I've checked the files view for spelling issues, code quality warnings and similar
- [ ] I've waited until all checks have passed (green check/without error)
- [ ] I've checked that only the intended files are changed
